### PR TITLE
Restore min default

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -18,14 +18,13 @@ name: ipydrawio-demo
 
 channels:
   - conda-forge
-  - nodefaults
 
 dependencies:
+  - python >=3.9
   # demo toys
   - bqplot
   - graphviz2drawio
   - jupyter-lsp-python-lsp-server
-  - jupyter-videochat
   - jupyterlab-classic
   - jupyterlab-lsp
   - jupyterlab-tour

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda index build/conda-bld
-          doit -s conda_test
+          doit -s conda_test || doit -s conda_test
 
   test:
     needs: [build]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### ipydrawio 1.1.1
 
-- adds `jupyter ipydrawio clean` for removing `host`, `agent`, `modified` attributes
-  and pretty printing [#44]
+- adds `jupyter ipydrawio clean` for removing `host`, `agent`, `modified`
+  attributes and pretty printing, restoring `lxml` as a dependency [#44]
 
 #### @deathbeds/ipydrawio 1.1.1
 
@@ -37,8 +37,8 @@
 ### ipydrawio 1.1.0
 
 - new documentation site at https://ipydrawio.rtfd.io [#40]
-- no longer depends on `lxml`, future XML-based features will support the
-  standard library `xml` module [#40]
+- no longer depends on `lxml`, future XML-based features will hopefully support
+  the standard library `xml` module [#40]
 
 #### @deathbeds/ipydrawio 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,18 @@
 
 ### ipydrawio 1.1.1
 
+- adds `jupyter ipydrawio clean` for removing `host`, `agent`, `modified` attributes
+  and pretty printing [#44]
+
 #### @deathbeds/ipydrawio 1.1.1
+
+- revert default theme from `sketch` back to `min` [#41]
 
 #### @deathbeds/ipydrawio-notebook 1.1.1
 
-#### @deathbeds/ipydrawio-webpack 14.7.500
+#### @deathbeds/ipydrawio-webpack 14.7.600
 
-- upgrade to drawio v14.7.5 for layer enhancements and various bugfixes
+- upgrade to drawio v14.7.6 for layer enhancements and various bugfixes [#51]
 
 #### @deathbeds/ipydrawio-jupyter-templates 1.1.1
 
@@ -22,6 +27,7 @@
 
 #### @deathbeds/ipydrawio-pdf 1.1.1
 
+[#41]: https://github.com/deathbeds/ipydrawio/issues/41
 [#44]: https://github.com/deathbeds/ipydrawio/issues/44
 
 ---

--- a/packages/ipydrawio-webpack/package.json
+++ b/packages/ipydrawio-webpack/package.json
@@ -43,5 +43,5 @@
     "build:pre": "python scripts/patch.py && python scripts/static.py"
   },
   "types": "lib/index.d.ts",
-  "version": "14.7.500"
+  "version": "14.7.600"
 }

--- a/packages/ipydrawio/package.json
+++ b/packages/ipydrawio/package.json
@@ -19,7 +19,7 @@
     "json-schema-to-typescript": "^10.1.4"
   },
   "peerDependencies": {
-    "@deathbeds/ipydrawio-webpack": "^14.7.500",
+    "@deathbeds/ipydrawio-webpack": "^14.7.600",
     "@jupyter-widgets/base": "4",
     "@jupyter-widgets/controls": "3",
     "@jupyter-widgets/jupyterlab-manager": "3"

--- a/packages/ipydrawio/schema/plugin.json
+++ b/packages/ipydrawio/schema/plugin.json
@@ -864,7 +864,7 @@
         "svg-warning": 0,
         "thumb": 0,
         "tr": 0,
-        "ui": "sketch"
+        "ui": "min"
       },
       "description": "URL parameters for the drawio iframe https://web.archive.org/web/20210425055302/https://www.diagrams.net/doc/faq/supported-url-parameters"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,7 +98,7 @@
     "@jupyterlab/application" "3"
 
 "@deathbeds/ipydrawio-webpack@file:packages/ipydrawio-webpack":
-  version "14.7.500"
+  version "14.7.600"
   dependencies:
     "@jupyterlab/application" "3"
 


### PR DESCRIPTION
- (re) fixes #41 by reverting to `min`
- removes jupyter-videochat (for now)